### PR TITLE
Update tendermint proto from 0.19 -> 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 [dependencies]
 failure = "0.1.6"
 log = "0.4.8"
-tendermint-proto = "0.19.0"
+tendermint-proto = "0.21.0"
 prost = "0.7.0"
 
 [[example]]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -29,51 +29,38 @@ fn handle_connection(i: usize, conn: Connection) {
         let req = conn.read().unwrap();
         println!("got request on connection {}: {:?}", i, req);
         // just send back some empty responses for the messages we'll get
-        let res = match req.value {
+        let value = match req.value {
             Some(request::Value::Info(_)) => {
                 let inner = tendermint_proto::abci::ResponseInfo::default();
-                let value = response::Value::Info(inner);
-                Response {
-                    value: value.into(),
-                }
+                response::Value::Info(inner)
             }
             Some(request::Value::InitChain(_)) => {
                 let inner = tendermint_proto::abci::ResponseInitChain::default();
-                let value = response::Value::InitChain(inner);
-                Response {
-                    value: value.into(),
-                }
+                response::Value::InitChain(inner)
             }
             Some(request::Value::BeginBlock(_)) => {
                 let inner = tendermint_proto::abci::ResponseBeginBlock::default();
-                let value = response::Value::BeginBlock(inner);
-                Response {
-                    value: value.into(),
-                }
+                response::Value::BeginBlock(inner)
             }
             Some(request::Value::EndBlock(_)) => {
                 let inner = tendermint_proto::abci::ResponseEndBlock::default();
-                let value = response::Value::EndBlock(inner);
-                Response {
-                    value: value.into(),
-                }
+                response::Value::EndBlock(inner)
             }
             Some(request::Value::Commit(_)) => {
                 let inner = tendermint_proto::abci::ResponseCommit::default();
-                let value = response::Value::Commit(inner);
-                Response {
-                    value: value.into(),
-                }
+                response::Value::Commit(inner)
             }
             Some(request::Value::Flush(_)) => {
                 let inner = tendermint_proto::abci::ResponseFlush::default();
-                let value = response::Value::Flush(inner);
-                Response {
-                    value: value.into(),
-                }
+                response::Value::Flush(inner)
             }
             _ => panic!("Unhandled request type: {:?}", req),
         };
+
+        let res = Response {
+            value: value.into(),
+        };
+
         println!("sending response on connection {}: {:?}", i, res);
 
         // send the response back to Tendermint

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,5 @@
 use abci2::{Connection, Server};
-use tendermint_proto::abci::request;
-use tendermint_proto::abci::response;
-use tendermint_proto::abci::{Request, Response};
+use tendermint_proto::abci::{request, response, Response};
 
 // you can run this example by doing `cargo run --example simple`
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,12 +1,17 @@
-use abci2::messages::abci;
-use abci2::{Server, Connection};
+use abci2::{Connection, Server};
+use tendermint_proto::abci::request;
+use tendermint_proto::abci::response;
+use tendermint_proto::abci::{Request, Response};
 
 // you can run this example by doing `cargo run --example simple`
 
 fn main() {
     // start listening
     let server = Server::listen("localhost:26658").unwrap();
-    println!("listening for ABCI connections on {}", server.local_addr().unwrap());
+    println!(
+        "listening for ABCI connections on {}",
+        server.local_addr().unwrap()
+    );
 
     // accept the 3 connections Tendermint is going to make, and handle incoming
     // requests in a separate thread for each
@@ -19,26 +24,58 @@ fn main() {
 }
 
 fn handle_connection(i: usize, conn: Connection) {
-    use abci::Request_oneof_value::*;
-
     // create a thread which reads a request then writes the response in a loop,
     // forever
     std::thread::spawn(move || loop {
         // get next incoming request
         let req = conn.read().unwrap();
         println!("got request on connection {}: {:?}", i, req);
-
         // just send back some empty responses for the messages we'll get
-        let mut res = abci::Response::new();
-        match req.value {
-            Some(info(_)) => res.set_info(abci::ResponseInfo::new()),
-            Some(init_chain(_)) => res.set_init_chain(abci::ResponseInitChain::new()),
-            Some(begin_block(_)) => res.set_begin_block(abci::ResponseBeginBlock::new()),
-            Some(end_block(_)) => res.set_end_block(abci::ResponseEndBlock::new()),
-            Some(commit(_)) => res.set_commit(abci::ResponseCommit::new()),
-            Some(flush(_)) => res.set_flush(abci::ResponseFlush::new()),
-            _ => panic!("Unhandled request type: {:?}", req)
-        }
+        let res = match req.value {
+            Some(request::Value::Info(_)) => {
+                let inner = tendermint_proto::abci::ResponseInfo::default();
+                let value = response::Value::Info(inner);
+                Response {
+                    value: value.into(),
+                }
+            }
+            Some(request::Value::InitChain(_)) => {
+                let inner = tendermint_proto::abci::ResponseInitChain::default();
+                let value = response::Value::InitChain(inner);
+                Response {
+                    value: value.into(),
+                }
+            }
+            Some(request::Value::BeginBlock(_)) => {
+                let inner = tendermint_proto::abci::ResponseBeginBlock::default();
+                let value = response::Value::BeginBlock(inner);
+                Response {
+                    value: value.into(),
+                }
+            }
+            Some(request::Value::EndBlock(_)) => {
+                let inner = tendermint_proto::abci::ResponseEndBlock::default();
+                let value = response::Value::EndBlock(inner);
+                Response {
+                    value: value.into(),
+                }
+            }
+            Some(request::Value::Commit(_)) => {
+                let inner = tendermint_proto::abci::ResponseCommit::default();
+                let value = response::Value::Commit(inner);
+                Response {
+                    value: value.into(),
+                }
+            }
+            Some(request::Value::Flush(_)) => {
+                let inner = tendermint_proto::abci::ResponseFlush::default();
+                let value = response::Value::Flush(inner);
+                Response {
+                    value: value.into(),
+                }
+            }
+            _ => panic!("Unhandled request type: {:?}", req),
+        };
         println!("sending response on connection {}: {:?}", i, res);
 
         // send the response back to Tendermint


### PR DESCRIPTION
Orga state-sync needs tendermint_proto upgrade to 0.21. Interaction with abci2 in abci/mod.rs cause type mismatches from abci2 function calls. Changes only required in simple example.